### PR TITLE
Changes hbs and css to allow additional currencies

### DIFF
--- a/styles/sfc.css
+++ b/styles/sfc.css
@@ -1,10 +1,14 @@
 .sfc .coins {
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
     gap: 0.5em;
 }
 
 .sfc .currency-display {
-    width: 100%;
+    grid-column: 1/-1;
+    display: flex;
+    gap: 0.5em;
+    align-items: center;
     white-space: nowrap;
 }
 
@@ -48,6 +52,8 @@
 .swade-official .sfc .coins.manager-button,
 .swpf-sheet .sfc .coins.manager-button {
     height: 27px;
+    align-content: center;
+    margin-left: auto;
 }
 
 .sfc .coin-group input {

--- a/templates/coins-display.hbs
+++ b/templates/coins-display.hbs
@@ -1,19 +1,19 @@
 <div class='sfc'>
     <div class='coins'>
-        {{#if showCurrency}}
         <div class="currency-display">
+            {{#if showCurrency}}
             {{#if currencyName}}
             <span class='label'>{{currencyName}}:</span>
             {{/if}}
             <span class='value'>{{numberFormat currencyAmount decimals=2}}</span>
+            {{/if}}
+            <button type="button" class="coins manager-button" id="manager-button">{{localize "SFC.CoinManager.ButtonName"}}</button>
         </div>
-        {{/if}}
         {{#each coinTemplateData}}
         <div class="coin-group">
             <label for="flags.sfc.{{countFlagName}}"><img name="icon-{{@index}}" src='{{img}}' class="coin-icon" data-tooltip="{{name}}" title='{{name}}' /></label>
             <input name='flags.sfc.{{countFlagName}}' type='number' data-dtype='Number' value='{{count}}' />
         </div>
         {{/each}}
-        <button type="button" class="coins manager-button" id="manager-button">{{localize "SFC.CoinManager.ButtonName"}}</button>
     </div>
 </div>


### PR DESCRIPTION
- Reconfigures the UI to a grid display allowing additional rows of currencies to be added as needed in support of #21 .
- Button to manage currencies is moved into the same containing element as the currency display, which spans above the currencies.
- The conditional for displaying currencies is now wrapped around the the currency display but within its container.